### PR TITLE
replace START_STICKY with START_REDELIVER_INTENT

### DIFF
--- a/android/src/main/java/com/carusto/ReactNativePjSip/PjSipModulePackage.java
+++ b/android/src/main/java/com/carusto/ReactNativePjSip/PjSipModulePackage.java
@@ -25,7 +25,6 @@ public class PjSipModulePackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/carusto/ReactNativePjSip/PjSipService.java
+++ b/android/src/main/java/com/carusto/ReactNativePjSip/PjSipService.java
@@ -241,7 +241,7 @@ public class PjSipService extends Service implements SensorEventListener {
                 intent.getAction().equals(PjActions.EVENT_APP_HIDDEN) ||
                 intent.getAction().equals(PjActions.EVENT_APP_DESTROY) ||
                 intent.getAction().equals(PjActions.EVENT_CONNECTIVITY_CHANGED)) {
-                return START_STICKY;
+                return START_REDELIVER_INTENT;
             }
 
             if (intent.hasExtra("service")) {
@@ -303,7 +303,7 @@ public class PjSipService extends Service implements SensorEventListener {
             }
         });
 
-        return START_STICKY;
+        return START_REDELIVER_INTENT;
     }
 
     @Override


### PR DESCRIPTION
Android app crashed every time after closing. Fixed the issue by replacing START_STICKY with START_REDELIVER_INTENT

reference: https://stackoverflow.com/questions/32731782/get-nullpointerexception-after-closing-application-android